### PR TITLE
The browser environment stops ESLint from giving error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,8 @@ module.exports = {
 
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "browser": true
   },
 
   "plugins": [


### PR DESCRIPTION
Include `env` with `browser`